### PR TITLE
#34 fix : like 페이지 최초 로딩시 실시간 반영 안되는 문제 해결

### DIFF
--- a/src/hooks/useInfinityLikeLoad.js
+++ b/src/hooks/useInfinityLikeLoad.js
@@ -24,7 +24,7 @@ const useInfinityLikeLoad = ({
   const getCurrentPageNumber = (list) => {
     const pageNumber = minimumLength
       ? list.length / minimumLength
-      : list.length * 0.1;
+      : list.length / MOVIE_PER_PAGE;
     return Number.isInteger(pageNumber) ? pageNumber : Math.ceil(pageNumber);
   };
 
@@ -46,7 +46,7 @@ const useInfinityLikeLoad = ({
       },
       callback,
     });
-  }, [queryTitle, queryYear, minimumLength]);
+  }, [queryTitle, queryYear, minimumLength, movieList]);
 
   useEffect(() => {
     getCurrentPageNumber(movieList) === 1 && setInitialLoading(false);


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- 라이크 페이지 최초 로딩 시 좋아요 취소 기능이 반영 안되는 문제 해결 